### PR TITLE
禁用管理员权限后，只能通过创建新分支来提交

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,5 @@
 - 扫描网址有效性，scan.php文件
 - 错误处理及日志，error.php文件
 - 单元测试，用的codeception,在tests\unit的WhovianTest.php中，可以直接运行`vendor/bin/codecept run`来执行
+
+顺便测试下分支保护、pull request等


### PR DESCRIPTION
当分支保护中的“Include administrators ”勾选后，即便是创建者，也不能随便提交，只能发起pull request，但由于创建者和本身是一个，自己不能自自己的master中提交pull request，所以只能新建分支，然后在提交。